### PR TITLE
feat: pass Bearer token credentials through to Rust client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,16 +368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eventstore-macros"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555f6f235f8f5eb1a88c2c24b9c29742c1b71423ddf431e3572dd5226e99f38"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "kurrentdb"
-version = "1.0.0-alpha.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ca80172a796514d13014d36fd5c9b73f2dbee0391309420276371f2ea2f8af"
+checksum = "b39067ccd6575c67e9e9e050bcb71342b011af2002e448bc6f57972d7f1b9d66"
 dependencies = [
  "async-stream",
  "base64",
@@ -944,13 +934,13 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "eventstore-macros",
  "eyre",
  "futures",
  "http",
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "kurrentdb-macros",
  "lazy_static",
  "nom",
  "prost",
@@ -971,6 +961,16 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+]
+
+[[package]]
+name = "kurrentdb-macros"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72884a70f83c9cdc7195bd0aef6fe9df5fa6a9eef4722170c6e90b4cf2b69672"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -32,4 +32,4 @@ version = "1"
 features = ["serde", "v4"]
 
 [dependencies.kurrentdb]
-version = "1.0.0-alpha.4"
+version = "1.1.0"

--- a/crates/bridge/src/client.rs
+++ b/crates/bridge/src/client.rs
@@ -65,13 +65,36 @@ fn authentication_from_js<'a>(
     cx: &mut FunctionContext<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<Authentication> {
-    if let Some(token) = obj.get_opt::<JsString, _, _>(cx, "bearerToken")? {
-        return Ok(Authentication::bearer(token.value(cx)));
+    let bearer_value = obj.get_value(cx, "bearerToken")?;
+    if !bearer_value.is_a::<JsUndefined, _>(cx) {
+        let token = match bearer_value.downcast::<JsString, _>(cx) {
+            Ok(s) => s.value(cx),
+            Err(_) => {
+                return cx.throw_type_error("credentials.bearerToken must be a string");
+            }
+        };
+        return Ok(Authentication::bearer(token));
     }
 
-    let login = obj.get::<JsString, _, _>(cx, "username")?.value(cx);
-    let password = obj.get::<JsString, _, _>(cx, "password")?.value(cx);
-    Ok(Authentication::basic(login, password))
+    let username = obj
+        .get_value(cx, "username")?
+        .downcast::<JsString, _>(cx)
+        .ok();
+    let password = obj
+        .get_value(cx, "password")?
+        .downcast::<JsString, _>(cx)
+        .ok();
+
+    match (username, password) {
+        (Some(u), Some(p)) => {
+            let login = u.value(cx);
+            let password = p.value(cx);
+            Ok(Authentication::basic(login, password))
+        }
+        _ => cx.throw_type_error(
+            "credentials must include either { bearerToken } or { username, password }",
+        ),
+    }
 }
 
 pub fn read_stream(client: Client, mut cx: FunctionContext) -> JsResult<JsPromise> {

--- a/crates/bridge/src/client.rs
+++ b/crates/bridge/src/client.rs
@@ -6,8 +6,8 @@ use neon::prelude::*;
 use crate::error::create_js_error;
 use crate::RUNTIME;
 use kurrentdb::{
-    Client, ClientSettings, Credentials, Position, ReadAllOptions, ReadStream, ReadStreamOptions,
-    RecordedEvent, ResolvedEvent, StreamPosition,
+    Authentication, Client, ClientSettings, Position, ReadAllOptions, ReadStream,
+    ReadStreamOptions, RecordedEvent, ResolvedEvent, StreamPosition,
 };
 use neon::{
     prelude::FunctionContext,
@@ -61,6 +61,19 @@ pub enum Options {
     All(ReadAllOptions),
 }
 
+fn authentication_from_js<'a>(
+    cx: &mut FunctionContext<'a>,
+    obj: Handle<'a, JsObject>,
+) -> NeonResult<Authentication> {
+    if let Some(token) = obj.get_opt::<JsString, _, _>(cx, "bearerToken")? {
+        return Ok(Authentication::bearer(token.value(cx)));
+    }
+
+    let login = obj.get::<JsString, _, _>(cx, "username")?.value(cx);
+    let password = obj.get::<JsString, _, _>(cx, "password")?.value(cx);
+    Ok(Authentication::basic(login, password))
+}
+
 pub fn read_stream(client: Client, mut cx: FunctionContext) -> JsResult<JsPromise> {
     let stream_name = cx.argument::<JsString>(0)?.value(&mut cx);
     let params = if cx.len() >= 2 {
@@ -103,13 +116,7 @@ pub fn read_stream(client: Client, mut cx: FunctionContext) -> JsResult<JsPromis
     }
 
     if let Some(obj) = params.get_opt::<JsObject, _, _>(&mut cx, "credentials")? {
-        let login = obj
-            .get::<JsString, _, _>(&mut cx, "username")?
-            .value(&mut cx);
-        let password = obj
-            .get::<JsString, _, _>(&mut cx, "password")?
-            .value(&mut cx);
-        options = options.authenticated(Credentials::new(login, password));
+        options = options.authenticated(authentication_from_js(&mut cx, obj)?);
     }
 
     if let Some(js_bigint) = params.get_opt::<JsBigInt, _, _>(&mut cx, "maxCount")? {
@@ -200,13 +207,7 @@ pub fn read_all(client: Client, mut cx: FunctionContext) -> JsResult<JsPromise> 
     };
 
     options = if let Some(obj) = params.get_opt::<JsObject, _, _>(&mut cx, "credentials")? {
-        let login = obj
-            .get::<JsString, _, _>(&mut cx, "username")?
-            .value(&mut cx);
-        let password = obj
-            .get::<JsString, _, _>(&mut cx, "password")?
-            .value(&mut cx);
-        options.authenticated(Credentials::new(login, password))
+        options.authenticated(authentication_from_js(&mut cx, obj)?)
     } else {
         options
     };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   esdb:
-    image: docker.eventstore.com/kurrent-latest/kurrentdb:latest
+    image: kurrentplatform/kurrentdb:lts
     ports:
       - 2113:2113
     environment:

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,13 +35,17 @@ export type RawClient = {
 
 export type RawReadStream = unknown;
 
+export type BasicCredentials = { username: string; password: string };
+export type BearerCredentials = { bearerToken: string };
+export type Credentials = BasicCredentials | BearerCredentials;
+
 export type RustReadStreamOptions = {
   fromRevision: bigint | string;
   direction: string;
   maxCount: bigint;
   requiresLeader: boolean;
   resolvesLink: boolean;
-  credentials?: { username: string; password: string };
+  credentials?: Credentials;
 };
 
 export type RustReadAllOptions = {
@@ -50,7 +54,7 @@ export type RustReadAllOptions = {
   maxCount: bigint;
   requiresLeader: boolean;
   resolvesLink: boolean;
-  credentials?: { username: string; password: string };
+  credentials?: Credentials;
   filter?: Filter;
 };
 

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -125,4 +125,31 @@ describe("read", () => {
 
     assert.strictEqual(events.length, 1);
   });
+
+  it("Should throw TypeError when bearerToken is not a string", async () => {
+    const client = addon.createClient("kurrentdb://localhost:2113?tls=false");
+
+    const stream = client.readStream(streamName, {
+      credentials: { bearerToken: 123 },
+    });
+
+    await assert.rejects(() => collectEvents(stream), {
+      name: "TypeError",
+      message: "credentials.bearerToken must be a string",
+    });
+  });
+
+  it("Should throw TypeError when credentials shape is invalid", async () => {
+    const client = addon.createClient("kurrentdb://localhost:2113?tls=false");
+
+    const stream = client.readStream(streamName, {
+      credentials: { username: "admin" },
+    });
+
+    await assert.rejects(() => collectEvents(stream), {
+      name: "TypeError",
+      message:
+        "credentials must include either { bearerToken } or { username, password }",
+    });
+  });
 });

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -98,10 +98,6 @@ describe("read", () => {
   });
 
   it("Should read with bearer-token credentials", async () => {
-    // The credential shape lives entirely on the JS side. The bridge picks the
-    // Bearer branch and the Rust client emits `Authorization: Bearer ...`. The
-    // test server runs in insecure mode and ignores the header, so success
-    // here proves the JS->Rust plumbing carries bearer tokens without error.
     const client = addon.createClient("kurrentdb://localhost:2113?tls=false");
 
     const stream = client.readStream(streamName, {

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -81,4 +81,48 @@ describe("read", () => {
       "Count should be 10 after reading all events"
     );
   });
+
+  it("Should read with basic credentials", async () => {
+    // Arrange
+    const client = addon.createClient("kurrentdb://localhost:2113?tls=false");
+
+    // Act
+    const stream = client.readStream(streamName, {
+      credentials: { username: "admin", password: "changeit" },
+    });
+
+    // Assert
+    const events = await collectEvents(stream);
+
+    assert.strictEqual(events.length, 4);
+  });
+
+  it("Should read with bearer-token credentials", async () => {
+    // The credential shape lives entirely on the JS side. The bridge picks the
+    // Bearer branch and the Rust client emits `Authorization: Bearer ...`. The
+    // test server runs in insecure mode and ignores the header, so success
+    // here proves the JS->Rust plumbing carries bearer tokens without error.
+    const client = addon.createClient("kurrentdb://localhost:2113?tls=false");
+
+    const stream = client.readStream(streamName, {
+      credentials: { bearerToken: "test-bearer-token" },
+    });
+
+    const events = await collectEvents(stream);
+
+    assert.strictEqual(events.length, 4);
+  });
+
+  it("Should read $all with bearer-token credentials", async () => {
+    const client = addon.createClient("kurrentdb://localhost:2113?tls=false");
+
+    const stream = client.readAll({
+      maxCount: 1n,
+      credentials: { bearerToken: "test-bearer-token" },
+    });
+
+    const events = await collectEvents(stream);
+
+    assert.strictEqual(events.length, 1);
+  });
 });


### PR DESCRIPTION
## Summary

- Bumps `kurrentdb` to `1.1.0` (the version DEV-1643 published with the new `Authentication` enum) and reworks the bridge to detect credential shape on the JS side: `{ bearerToken }` becomes `Authentication::Bearer`, `{ username, password }` becomes `Authentication::Basic`.
- Widens `RustReadStreamOptions.credentials` and `RustReadAllOptions.credentials` to a `Credentials = BasicCredentials | BearerCredentials` discriminated union, mirroring the Node client's shape from DEV-1642.
- Adds bridge-level integration tests for both `readStream` and `readAll` covering basic and bearer credentials. The tests run against the existing insecure docker-compose KurrentDB; success proves the JS->Rust plumbing carries bearer tokens without error (header structure is independently verified by the Rust crate's unit tests in DEV-1643).

Closes DEV-1644. Once this is published, `packages/db-client/src/streams/{readStream,readAll}.ts` in the Node client can drop their bearer-token guard and resolve `authorizationHeaderProvider` into a `Credentials` value before calling the bridge, closing DEV-1341.

## Out of scope of this PR

- Rebuilding platform binaries via `release-package.yml` and publishing the new `@kurrent/bridge` npm version — those run as the workflow-driven release step after merge.

## Test plan

- [x] `cargo build -p bridge` succeeds against `kurrentdb = 1.1.0`.
- [x] `npx tsc` produces the updated `lib/index.d.ts` with the discriminated union.
- [x] `node --test` — all 12 tests pass against `docker compose up -d` KurrentDB, including the 3 new credential cases.
- [ ] CI matrix (Linux x64/arm64, macOS x64/arm64, Windows x64) builds the Neon binaries on the release workflow.