### PR TITLE
Fix lossy u64 serialization by emitting decimal strings

### DIFF
--- a/crates/bridge/src/client.rs
+++ b/crates/bridge/src/client.rs
@@ -328,7 +328,7 @@ struct ValueItem<'a> {
 struct JsResolvedEvent<'a> {
     event: Option<JsRecordedEvent<'a>>,
     link: Option<JsRecordedEvent<'a>>,
-    commit_position: Option<u64>,
+    commit_position: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -338,7 +338,7 @@ struct JsRecordedEvent<'a> {
     id: Uuid,
     r#type: &'a str,
     is_json: bool,
-    revision: u64,
+    revision: String,
     created: DateTime<Utc>,
     data: &'a [u8],
     metadata: &'a [u8],
@@ -347,12 +347,12 @@ struct JsRecordedEvent<'a> {
 
 #[derive(Serialize)]
 struct JsPosition {
-    commit: u64,
-    prepare: u64,
+    commit: String,
+    prepare: String,
 }
 
 fn js_resolve_event(event: &ResolvedEvent) -> JsResolvedEvent {
-    let commit_position = event.commit_position;
+    let commit_position = event.commit_position.map(|p| p.to_string());
     let link = event.link.as_ref().map(js_recorded_event);
     let event = event.event.as_ref().map(js_recorded_event);
 
@@ -369,13 +369,13 @@ fn js_recorded_event(event: &RecordedEvent) -> JsRecordedEvent {
         id: event.id,
         r#type: event.event_type.as_str(),
         is_json: event.is_json,
-        revision: event.revision,
+        revision: event.revision.to_string(),
         created: event.created,
         data: &event.data,
         metadata: &event.custom_metadata,
         position: JsPosition {
-            commit: event.position.commit,
-            prepare: event.position.prepare,
+            commit: event.position.commit.to_string(),
+            prepare: event.position.prepare.to_string(),
         },
     }
 }

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -48,6 +48,30 @@ describe("read", () => {
     );
   });
 
+  it("Should serialize revision and position as lossless strings", async () => {
+    // Arrange
+    const client = addon.createClient("kurrentdb://localhost:2113?tls=false");
+
+    // Act
+    const [resolved] = await collectEvents(client.readStream(streamName));
+
+    // Assert
+    assert.strictEqual(typeof resolved.event.revision, "string");
+    assert.strictEqual(typeof resolved.event.position.commit, "string");
+    assert.strictEqual(typeof resolved.event.position.prepare, "string");
+  });
+
+  it("Should serialize commitPosition as a string when reading $all", async () => {
+    // Arrange
+    const client = addon.createClient("kurrentdb://localhost:2113?tls=false");
+
+    // Act
+    const [resolved] = await collectEvents(client.readAll({ maxCount: 1n }));
+
+    // Assert
+    assert.strictEqual(typeof resolved.commitPosition, "string");
+  });
+
   it("Should read a limited number of events from a single stream", async () => {
     // Arrange
     const client = addon.createClient("kurrentdb://localhost:2113?tls=false");


### PR DESCRIPTION
Serialize `u64` fields (`revision`, `position.commit`/`prepare`, `commitPosition`) as decimal strings instead of JSON numbers. Numbers lose precision above `2^53` in `JSON.parse` and surface as `number` despite the `bigint` types. Strings survive `JSON.parse` losslessly; the client converts them with `BigInt(...)`.

Bridge-side root cause of [KurrentDB-Client-NodeJS#513](https://github.com/kurrent-io/KurrentDB-Client-NodeJS/issues/513).