### PR TITLE
Return event created as epoch milliseconds instead of a Date

### DIFF
--- a/crates/bridge/src/client.rs
+++ b/crates/bridge/src/client.rs
@@ -11,7 +11,7 @@ use kurrentdb::{
 use neon::{
     prelude::FunctionContext,
     result::JsResult,
-    types::{JsBigInt, JsBoolean, JsDate, JsFunction, JsObject, JsPromise, JsString, JsValue},
+    types::{JsBigInt, JsBoolean, JsFunction, JsObject, JsPromise, JsString, JsValue},
 };
 use tokio::sync::{Mutex};
 
@@ -335,7 +335,7 @@ fn js_recorded_event<'a, C: Context<'a>>(
     let revision = JsBigInt::from_u64(cx, event.revision);
     obj.set(cx, "revision", revision)?;
 
-    let created = JsDate::new_lossy(cx, event.created.timestamp_millis() as f64);
+    let created = cx.number(event.created.timestamp_millis() as f64);
     obj.set(cx, "created", created)?;
 
     let data = JsBuffer::from_slice(cx, &event.data)?;

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export type RecordedEvent = {
   type: string;
   isJson: boolean;
   revision: bigint;
-  created: Date;
+  created: number;
   data: Uint8Array;
   metadata: Uint8Array;
   position?: Position;

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -59,7 +59,7 @@ describe("read", () => {
     assert.strictEqual(typeof resolved.event.revision, "bigint");
     assert.strictEqual(typeof resolved.event.position.commit, "bigint");
     assert.strictEqual(typeof resolved.event.position.prepare, "bigint");
-    assert.ok(resolved.event.created instanceof Date);
+    assert.strictEqual(typeof resolved.event.created, "number");
     assert.ok(Buffer.isBuffer(resolved.event.data));
     assert.ok(Buffer.isBuffer(resolved.event.metadata));
   });


### PR DESCRIPTION
`created` was built as a JS `Date` in the addon's (host) realm. In sandboxed multi-realm environments (jest, `vm`, workers) that fails `created instanceof Date` against the consumer realm's `Date`, even though the value is a valid date.

Return `created` as epoch milliseconds (a `number`) and let the client construct the `Date` in its own realm, restoring `instanceof Date` everywhere. `number` is lossless for dates (max date is well under `Number.MAX_SAFE_INTEGER`).